### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:alpine
+FROM rust:slim-bullseye
 
-RUN apk update && \
-    apk upgrade && \
-    apk add --no-cache pkgconfig openssl-dev musl-dev
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y musl-dev pkg-config libssl-dev
 
 WORKDIR /usr/src/myapp
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:alpine
+
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache pkgconfig openssl-dev musl-dev
+
+WORKDIR /usr/src/myapp
+COPY . .
+
+RUN cargo install --path .
+
+ENTRYPOINT ["/usr/local/cargo/bin/nostcat"]
+
+CMD ["--help"]


### PR DESCRIPTION
I've added a Dockerfile so that nostcat can be built and run in a Docker container, in case e.g. one doesn't want to install Rust on their host OS.