### PR TITLE
Fix GLIBC Compatibility Issue for `nostcat` in Alpine-based Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN echo 'openssl = { version = "0.10", features = ["vendored"] }' >> /app/Cargo
 RUN cargo build --release
 RUN strip /app/target/release/nostcat
 
+# Download glibc library of distroless
+FROM gcr.io/distroless/cc-debian12:latest-amd64 AS glibc
 # We do not need the Rust toolchain to run the binary!
 FROM alpine:3.14 AS runtime
 RUN apk add openssl openssl-dev
@@ -39,4 +41,5 @@ RUN apk del libstdc++ curl
 RUN rm -rf /var/lib/apt/lists/*
 WORKDIR app
 COPY --from=builder /app/target/release/nostcat /usr/local/bin
+COPY --from=glibc /lib/x86_64-linux-gnu/* /usr/glibc-compat/lib/
 ENTRYPOINT ["/usr/local/bin/nostcat"]


### PR DESCRIPTION
#### Issue:
The `nostcat` binary, when executed in the existing Alpine-based Docker image, encounters an issue due to the absence of required GLIBC versions (2.32, 2.33, 2.34). Alpine, by default, uses musl libc, which is not compatible with glibc-dependent binaries. This results in the following error when running `nostcat`:
```
/usr/local/bin/nostcat: /usr/glibc-compat/lib/libc.so.6: version `GLIBC_2.33' not found (required by /usr/local/bin/nostcat)
/usr/local/bin/nostcat: /usr/glibc-compat/lib/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/bin/nostcat)
/usr/local/bin/nostcat: /usr/glibc-compat/lib/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/nostcat)
```

#### Proposed Solution:
This PR addresses the issue by introducing a multi-stage Docker build process. The key steps are:

1. **GLIBC Extraction**: We use `gcr.io/distroless/cc-debian12:latest-amd64` as a source to extract the GLIBC library. This distroless image is based on Debian 12 and contains the necessary GLIBC versions.

2. **Copy to Alpine Image**: The extracted GLIBC files are then copied to the Alpine-based runtime image at `/usr/glibc-compat/lib/`. This allows the `nostcat` binary to access the required GLIBC versions within the Alpine environment.

#### Implementation:
```Dockerfile
# Download glibc library from distroless container image
FROM gcr.io/distroless/cc-debian12:latest-amd64 AS glibc
# ... existing steps ...
# Copy the GLIBC files to the final image
COPY --from=glibc /lib/x86_64-linux-gnu/* /usr/glibc-compat/lib/
```

#### Benefits:
- **Compatibility**: Ensures that `nostcat` runs successfully in the lightweight Alpine container by resolving the GLIBC version mismatch.
- **Minimal Changes**: The change is minimal and isolated, avoiding a complete overhaul of the existing Docker setup.

#### Considerations:
- This solution focuses on resolving the immediate compatibility issue. However, for long-term maintenance, considering a glibc-based image or removing the glibc dependency in `nostcat` might be beneficial.

I look forward to your feedback on this proposed fix and am happy to make further modifications as needed.